### PR TITLE
Remove proxy 35.155.49.147

### DIFF
--- a/mainnet/mainnet-nodes/README.md
+++ b/mainnet/mainnet-nodes/README.md
@@ -245,7 +245,6 @@ Note: TLS port is currently not supported by Hedera SDKs
       </td>
       <td style="text-align:left">
         <p>34.82.78.255</p>
-        <p>35.155.49.147</p>
         <p>13.77.151.212</p>
       </td>
       <td style="text-align:left">50211, 50212 (TLS)</td>


### PR DESCRIPTION
Remove proxy 35.155.49.147. This proxy was decommissioned during the v0.16.1 Mainnet upgrade.