### PR TITLE
Link solidity files to filenames in deploy contract using HTS example

### DIFF
--- a/getting-started/try-examples/deploy-a-contract-using-the-hedera-token-service.md
+++ b/getting-started/try-examples/deploy-a-contract-using-the-hedera-token-service.md
@@ -24,9 +24,9 @@ The HTS.sol will serve as a reference to the contract that was compiled. The HTS
 
 To write a contract using HTS, you will need to add the HTS Solidity support libraries to your project and import them into your contract. Please see the HTS.sol example for reference. The IHederaTokenService.sol will need to be in the same directory as the other two files. An explanation of the functions can be found [here](../../docs/sdks/smart-contracts/hedera-service-solidity-libraries.md).
 
-* <mark style="color:purple;">HederaResponseCodes.sol</mark>
-* <mark style="color:purple;">HederaTokenService.sol</mark>
-* <mark style="color:purple;">IHederaTokenService.sol</mark>
+* [HederaTokenService.sol](https://github.com/hashgraph/hedera-smart-contracts/blob/main/hts-precompile/HederaTokenService.sol)
+* [HederaResponseCodes.sol](https://github.com/hashgraph/hedera-smart-contracts/blob/main/hts-precompile/HederaResponseCodes.sol)
+* [IHederaTokenService.sol ](https://github.com/hashgraph/hedera-smart-contracts/blob/main/hts-precompile/IHederaTokenService.sol)
 
 {% tabs %}
 {% tab title="HTS.sol" %}


### PR DESCRIPTION
**Description**:
This PR modifies deploy-a-contract-using-hedera-token-service.md in order to support linking to the resources it mentions
* Link solidity files to filenames
