### PR TITLE
remove documentation for deprecated GET contract query param (#81)

### DIFF
--- a/docs/mirror-node-api/rest-api.md
+++ b/docs/mirror-node-api/rest-api.md
@@ -1509,10 +1509,6 @@ The ID of the schedule to return the information for.
 Returns a list of all contract entity items on the network.
 {% endswagger-description %}
 
-{% swagger-parameter in="query" name="contractId" type="String" %}
-The ID of the contract to return information for
-{% endswagger-parameter %}
-
 {% swagger-parameter in="query" name="limit" type="integer" %}
 The limit of items to return
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

There is a query param listed in the docs that appears to be broken/deprecated. It could be that the actual fix is to accept that query param, but seems unnecessary given the other GET contract endpoint.

**Related issue(s)**:

Fixes #81

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
