### PR TITLE
Use Testnet instead of Mainnet IP for Client.forNetwork() JS example code

### DIFF
--- a/docs/sdks/client.md
+++ b/docs/sdks/client.md
@@ -53,7 +53,7 @@ Client.forNetwork(nodes);
 const client = Client.forTestnet();
 
 //For a specified network
-const nodes = {"35.237.200.180:50211": new AccountId(3)}
+const nodes = {"34.94.106.61:50211": new AccountId(10)}
 const client = Client.forNetwork(nodes);
 
 //v2.0.7


### PR DESCRIPTION
**Description**
The example JavaScript code for how to use `Client.forNetwork()`  uses a Mainnet IP which threw me off when I was expecting to connect to a Testnet node. This improvement updates the example IP address to use a Testnet node instead of a Mainnet and brings it inline with the other examples for Java and Go.