### PR TITLE
Update metadata link from HIP 10 to HIP 412

### DIFF
--- a/docs/sdks/tokens/mint-a-token.md
+++ b/docs/sdks/tokens/mint-a-token.md
@@ -6,7 +6,7 @@ Minting fungible token allows you to increase the total supply of the token. Min
 * The amount provided must be in the lowest denomination possible.
   * Example: Token A has 2 decimals. In order to mint 100 tokens, one must provide an amount of 10000. In order to mint 100.55 tokens, one must provide an amount of 10055.
 * The metadata field is specific to NFTs. Once an NFT is minted, the metadata cannot be changed and is immutable.
-  * You can use the metadata field to add a URI that contains additional information about the token. You can view the metadata schema [here](https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-10.md). The metadata field has a 100 character limit.
+  * You can use the metadata field to add a URI that contains additional information about the token. You can view the metadata schema [here](https://hips.hedera.com/hip/hip-412). The metadata field has a 100 character limit.
 * The serial number for the NFT is returned in the receipt of the transaction.
 * When minting NFTs, do not set the amount. The amount is used for minting fungible tokens only.
 


### PR DESCRIPTION
**Description**:
The HIP 10 metadata schema was superseded by HIP 412, this PR just updates the link to the new schema docs.