### PR TITLE
Adding in a new Mirror Node provider

### DIFF
--- a/mirrornet/hedera-mirror-node.md
+++ b/mirrornet/hedera-mirror-node.md
@@ -8,7 +8,7 @@ The Hedera Consensus Service (HCS) gRPC API is a public mirror node managed by H
 
 ### Mainnet:
 
-The non-production public mainnet mirror node serves to help developers build their applications without having to run their own mirror node. For production-ready mainnet mirror nodes please check out **** [Dragonglass](https://dragonglass.me/), [Kabuto](https://kabuto.sh/), or [Ledger Works](http://lworks.io/). When building your Hedera client via SDK, you can use `setMirrorNetwork()` and enter the public mainnet mirror node endpoint. The gRPC API requires TLS. The following SDK versions support TLS:
+The non-production public mainnet mirror node serves to help developers build their applications without having to run their own mirror node. For production-ready mainnet mirror nodes please check out **** [Arkhia](https://www.arkhia.io/), [Dragonglass](https://dragonglass.me/), [Kabuto](https://kabuto.sh/), or [Ledger Works](http://lworks.io/). When building your Hedera client via SDK, you can use `setMirrorNetwork()` and enter the public mainnet mirror node endpoint. The gRPC API requires TLS. The following SDK versions support TLS:
 
 * **Java:** v2.0.6+
 * **JavaScript:** v2.0.23+


### PR DESCRIPTION
Adding in the new mirror node service powered by BCW Group (https://bcw.group/)

Note: This is a content change only. The provider was added in alphabetic order as per the current providers.