### PR TITLE
Remove await keyword from sync PrivateKey methods in JS examples

### DIFF
--- a/docs/sdks/keys/create-a-threshold-key.md
+++ b/docs/sdks/keys/create-a-threshold-key.md
@@ -40,13 +40,13 @@ System.out.println("The 1/3 threshold key structure" +thresholdKey);
 {% endcode %}
 
 {% code title="JavaScript" %}
-```java
+```javascript
 // Generate our key lists
 const privateKeyList = [];
 const publicKeyList = [];
 for (let i = 0; i < 4; i += 1) {
      // eslint-disable-next-line no-await-in-loop
-     const privateKey = await PrivateKey.generate();
+     const privateKey = PrivateKey.generate();
      const publicKey = privateKey.publicKey;
      privateKeyList.push(privateKey);
      publicKeyList.push(publicKey);
@@ -64,7 +64,7 @@ console.log("The 1/3 threshold key structure" +thresholdKey);
 {% endcode %}
 
 {% code title="Go" %}
-```java
+```go
 //Generate 3 keys
 key1, err := hedera.GeneratePrivateKey()
 

--- a/docs/sdks/keys/generate-a-new-key-pair.md
+++ b/docs/sdks/keys/generate-a-new-key-pair.md
@@ -76,7 +76,7 @@ System.out.println("public key = " + newPublicKey);
 
 {% code title="JavaScript " %}
 ```javascript
-const privateKey = await PrivateKey.generate();
+const privateKey = PrivateKey.generate();
 const publicKey = privateKey.publicKey;
 
 console.log("private = " + privateKey);

--- a/getting-started/create-an-account.md
+++ b/getting-started/create-an-account.md
@@ -83,7 +83,7 @@ PublicKey newAccountPublicKey = newAccountPrivateKey.getPublicKey();
 //-----------------------<enter code below>--------------------------------------
 
 //Create new keys
-const newAccountPrivateKey = await PrivateKey.generateED25519(); 
+const newAccountPrivateKey = PrivateKey.generateED25519(); 
 const newAccountPublicKey = newAccountPrivateKey.publicKey;
 ```
 {% endtab %}
@@ -323,7 +323,7 @@ async function main() {
     client.setOperator(myAccountId, myPrivateKey);
 
     //Create new keys
-    const newAccountPrivateKey = await PrivateKey.generateED25519(); 
+    const newAccountPrivateKey = PrivateKey.generateED25519(); 
     const newAccountPublicKey = newAccountPrivateKey.publicKey;
 
     //Create a new account with 1,000 tinybar starting balance

--- a/getting-started/transfer-hbar.md
+++ b/getting-started/transfer-hbar.md
@@ -280,7 +280,7 @@ async function main() {
     client.setOperator(myAccountId, myPrivateKey);
 
     //Create new keys
-    const newAccountPrivateKey = await PrivateKey.generateED25519(); 
+    const newAccountPrivateKey = PrivateKey.generateED25519(); 
     const newAccountPublicKey = newAccountPrivateKey.publicKey;
 
     //Create a new account with 1,000 tinybar starting balance

--- a/getting-started/try-examples/deploy-a-contract-using-the-hedera-token-service.md
+++ b/getting-started/try-examples/deploy-a-contract-using-the-hedera-token-service.md
@@ -957,7 +957,7 @@ async function main() {
     const bytecode = htsContract.data.bytecode.object;
 
     //Treasury Key
-    const treasuryKey = await PrivateKey.generateED25519();
+    const treasuryKey = PrivateKey.generateED25519();
 
     //Create token treasury account
     const treasuryAccount = new AccountCreateTransaction()


### PR DESCRIPTION
**Description**:
1. Remove await keyword from sync PrivateKey methods in JS examples
2. Small fix to code block formatting