### PR TITLE
Add note on interface bonding

### DIFF
--- a/mainnet/mainnet-nodes/node-requirements/README.md
+++ b/mainnet/mainnet-nodes/node-requirements/README.md
@@ -84,6 +84,13 @@ Proxy Connectivity
 * TCP Port 50211 open to 0.0.0.0/0
 * TCP Port 50212 open to 0.0.0.0/0
 
+Interface Bonding (optional)
+
+* If using interface bonding, note that mutual TLS is in use, and Layer 3
+  Policy Based Routing (PBR) with dual-pathways is not supported. Only Layer
+  2 interface bonding using mode 1 (autonomous ports using active-backup)
+  or mode 4 (LACP 802.3ad active/active) is supported.
+
 ### Hosting
 
 * Industry standard hosting requirements for security and availability


### PR DESCRIPTION
**Description**:
Interface bonding can be used to provide redundancy and improve performance by combining two network interfaces into a single one.

eftpos was asking about what our requirements are, and I believe this has also come up in the past, so added them to the guide.

**Related issue(s)**:

**Notes for reviewer**:

This is a documentation change identified as an RCA item for eftpos

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
