### PR TITLE
Update JSON RPC info to "in beta"

### DIFF
--- a/core-concepts/smart-contracts/json-rpc-relay.md
+++ b/core-concepts/smart-contracts/json-rpc-relay.md
@@ -2,6 +2,8 @@
 
 The [Hedera JSON-RPC Relay](https://github.com/hashgraph/hedera-json-rpc-relay) is an open source project that implements the Ethereum JSON-RPC standard. The JSON-RPC relay allows developers to interact with Hedera nodes using familiar Ethereum tools. This allows Ethereum developers and users to deploy, query and execute contracts as they normally would. Check out the interact-able[ OpenRPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/openrpc.json\&uiSchema%5BappBar%5D%5Bui:splitView%5D=false\&uiSchema%5BappBar%5D%5Bui:input%5D=false\&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) and a simple [list of endpoints](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/rpc-api.md).&#x20;
 
+**The Hashio JSON-RPC relay implementation is in beta, offers limited functionality today, and is only available to developers.** To contribute feedback or log errors, please submit them as issues in the [GitHub repository](https://github.com/hashgraph/hedera-json-rpc-relay/issues).&#x20;
+
 To run an instance of the relay checkout the following:
 
 * [Locally using npm](https://github.com/hashgraph/hedera-json-rpc-relay#steps)

--- a/core-concepts/smart-contracts/json-rpc-relay.md
+++ b/core-concepts/smart-contracts/json-rpc-relay.md
@@ -2,7 +2,7 @@
 
 The [Hedera JSON-RPC Relay](https://github.com/hashgraph/hedera-json-rpc-relay) is an open source project that implements the Ethereum JSON-RPC standard. The JSON-RPC relay allows developers to interact with Hedera nodes using familiar Ethereum tools. This allows Ethereum developers and users to deploy, query and execute contracts as they normally would. Check out the interact-able[ OpenRPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/openrpc.json\&uiSchema%5BappBar%5D%5Bui:splitView%5D=false\&uiSchema%5BappBar%5D%5Bui:input%5D=false\&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) and a simple [list of endpoints](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/rpc-api.md).&#x20;
 
-**The Hashio JSON-RPC relay implementation is in beta, offers limited functionality today, and is only available to developers.** To contribute feedback or log errors, please submit them as issues in the [GitHub repository](https://github.com/hashgraph/hedera-json-rpc-relay/issues).&#x20;
+**The Hedera JSON-RPC relay implementation is in beta, offers limited functionality today, and is only available to developers.** To contribute feedback or log errors, please submit them as issues in the [GitHub repository](https://github.com/hashgraph/hedera-json-rpc-relay/issues).&#x20;
 
 To run an instance of the relay checkout the following:
 


### PR DESCRIPTION
**Description**:
The DA team has identified that a lot of questions come up around the JSON RPC (especially issues). However, it's not clear to users that the JSON RPC is still in beta while users assume this product works seamlessly. 