### PR TITLE
Remove reference to eslint in javascript example for threshold keys

### DIFF
--- a/docs/sdks/keys/create-a-threshold-key.md
+++ b/docs/sdks/keys/create-a-threshold-key.md
@@ -45,7 +45,6 @@ System.out.println("The 1/3 threshold key structure" +thresholdKey);
 const privateKeyList = [];
 const publicKeyList = [];
 for (let i = 0; i < 4; i += 1) {
-     // eslint-disable-next-line no-await-in-loop
      const privateKey = PrivateKey.generate();
      const publicKey = privateKey.publicKey;
      privateKeyList.push(privateKey);


### PR DESCRIPTION
Signed-off-by: Michael Garber <michael.garber@swirldslabs.com>