### PR TITLE
Update create-and-transfer-an-nft-using-a-solidity-contract.md

### DIFF
--- a/getting-started/try-examples/create-and-transfer-an-nft-using-a-solidity-contract.md
+++ b/getting-started/try-examples/create-and-transfer-an-nft-using-a-solidity-contract.md
@@ -47,9 +47,10 @@ import './HederaResponseCodes.sol';
 import './IHederaTokenService.sol';
 import './HederaTokenService.sol';
 import './ExpiryHelper.sol';
+import './KeyHelper.sol'
 
 
-contract NFTCreator is ExpiryHelper {
+contract NFTCreator is ExpiryHelper, KeyHelper, HederaTokenService {
 
     function createNft(
             string memory name, 


### PR DESCRIPTION
**Description**:
This PR modifies the `NFTCreator` smart contract in the [Create and Transfer an NFT using a Solidity Contract](https://docs.hedera.com/hedera/getting-started/try-examples/create-and-transfer-an-nft-using-a-solidity-contract) example to: 

- Import `KeyHelper.sol` and extend the `KeyHelper` contract, adding missing declarations for `getSingleKey` `KeyType` and `KeyValueType` which are required for the contract to compile.
- Extend `HederaTokenService` to enable the `NFTCreator` contract have access to the `createNonFungibleToken` internal method.

**Note to reviewers**

- The `NFTCreator` throws compile errors without these modifications as seen here: 

### Compile error for missing `getSingleKey` `KeyType` and `KeyValueType` declarations
![Screenshot 2023-01-18 at 02 20 22 (2)](https://user-images.githubusercontent.com/67528283/213057771-46be753f-239e-43e3-870d-4e9292b1258e.png)

<br/>

### Compile error for no-access to internal method:
![Screenshot 2023-01-18 at 02 24 20 (2)](https://user-images.githubusercontent.com/67528283/213058073-48cf7bb3-06bc-4fca-a975-965502b7e1ed.png)




