### PR TITLE
update mainnet mirrornode REST api endpoint url

### DIFF
--- a/mirrornet/hedera-mirror-node.md
+++ b/mirrornet/hedera-mirror-node.md
@@ -46,7 +46,7 @@ client.SetMirrorNetwork([]string{"mainnet-public.mirrornode.hedera.com:443"})
 {% hint style="info" %}
 **Mainnet Mirror Node Endpoint:** [mainnet-public.mirrornode.hedera.com](http://mainnet-public.mirrornode.hedera.com/):443\
 \
-**REST API Mainnet Root Endpoint:**[ https://mainnet-public.mirrornode.hedera.com](https://mainnet.mirrornode.hedera.com/)****
+**REST API Mainnet Root Endpoint:**[ https://mainnet-public.mirrornode.hedera.com](https://mainnet-public.mirrornode.hedera.com/)****
 {% endhint %}
 
 ### Testnet:


### PR DESCRIPTION
currently mainnet REST api is pointing to `https://mainnet.mirrornode.hedera.com/`, this change is update that url to correct url i.e. `https://mainnet-public.mirrornode.hedera.com/`

### Problem

currently mainnet REST api is pointing to `https://mainnet.mirrornode.hedera.com/` which is incorrect url

### Solution
This PR modifies that url to correct url i.e. `https://mainnet-public.mirrornode.hedera.com`

**Checklist**

- [x] Documented (Code comments, README, etc.)
