### PR TITLE
Fix minor typo in adjust an allowance page

### DIFF
--- a/docs/sdks/cryptocurrency/adjust-an-allowance.md
+++ b/docs/sdks/cryptocurrency/adjust-an-allowance.md
@@ -25,7 +25,7 @@ The total number of NFT serial number deletions contained within the transaction
 
 | **Method**                                          | **Type**                                                                                    | **Description**                                     |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `deleteAllNftAllowances(<nftId>, <ownerAccountId>)` | <p>NFT ID,<br><a href="../deprecated/sdks/specialized-types.md#accountid">AccountId</a></p> | Removes the NFT allowance from the spender account. |
+| `deleteAllTokenNftAllowances(<nftId>, <ownerAccountId>)` | <p>NFT ID,<br><a href="../deprecated/sdks/specialized-types.md#accountid">AccountId</a></p> | Removes the NFT allowance from the spender account. |
 
 {% tabs %}
 {% tab title="Java" %}


### PR DESCRIPTION
Signed-off-by: Petar Tonev <petar.tonev@limechain.tech>

**Description**:
This PR fixes a minor typo in adjust an allowance page where there is an example of `deleteAllTokenNftAllowances()` functionality of the AccountAllowanceDeleteTX

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
There is an inconsistency between the method description and the examples of each SDK. The right naming is stated in the examples as follows: `deleteAllTokenNftAllowances()`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
