### PR TITLE
Update generate-a-new-key-pair.md

### DIFF
--- a/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
+++ b/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
@@ -18,8 +18,8 @@ Create a new _**ED25519**_ key pair used to sign transactions and queries on the
 PrivateKey privateKey = PrivateKey.generateED25519();
 PublicKey publicKey = privateKey.getPublicKey();
 
-System.out.println("private = " + privateKey);
-System.out.println("public = " + publicKey);
+System.out.println("private key = " + privateKey);
+System.out.println("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -28,8 +28,8 @@ System.out.println("public = " + publicKey);
 const privateKey = await PrivateKey.generateED25519Async();
 const publicKey = privateKey.publicKey;
 
-console.log("private = " + privateKey);
-console.log("public = " + publicKey);
+console.log("private key = " + privateKey);
+console.log("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -42,8 +42,8 @@ if err != nil {
 
 publicKey := privateKey.PublicKey()
 
-fmt.Printf("private = %v\n", privateKey)
-fmt.Printf("public = %v\n", publicKey)
+fmt.Printf("private key = %v\n", privateKey)
+fmt.Printf("public key = %v\n", publicKey)
 ```
 {% endtab %}
 {% endtabs %}
@@ -72,18 +72,18 @@ Create a new _**ECDSA**_ (secp256k1) key pair used to sign transactions and quer
 PrivateKey privateKey = PrivateKey.generateECDSA();
 PublicKey publicKey = privateKey.getPublicKey();
 
-System.out.println("private = " + privateKey);
-System.out.println("public = " + publicKey);
+System.out.println("private key = " + privateKey);
+System.out.println("public key = " + publicKey);
 ```
 {% endtab %}
 
 {% tab title="JavaScript" %}
 ```javascript
 const privateKey = PrivateKey.generateECDSA();
-const publicKey = privateKey.publicKey();
+const publicKey = privateKey.publicKey;
 
-console.log("private = " + privateKey);
-console.log("public = " + publicKey);
+console.log("private key = " + privateKey);
+console.log("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -96,8 +96,8 @@ if err != nil {
 
 publicKey := privateKey.PublicKey()
 
-fmt.Printf("private = %v\n", privateKey)
-fmt.Printf("public = %v\n", publicKey)
+fmt.Printf("private key = %v\n", privateKey)
+fmt.Printf("public key = %v\n", publicKey)
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
This commit fixes an error in the Javascript example code for making an ECDSA key. The old code treated publicKey as a method, when it is an attribute.  The word "key" was also added to all the print statements to make them match the given Sample Output.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
