### PR TITLE
Update environment-set-up.md - Add version and keywords to default output of `npm init`

### DIFF
--- a/getting-started/environment-set-up.md
+++ b/getting-started/environment-set-up.md
@@ -482,7 +482,5 @@ func main() {
 
 
 {% hint style="info" %}
-Have a question? [Ask it on StackOverflow  "version": "",
-57
-](https://stackoverflow.com/questions/tagged/hedera-hashgraph)
+Have a question? [Ask it on StackOverflow](https://stackoverflow.com/questions/tagged/hedera-hashgraph)
 {% endhint %}

--- a/getting-started/environment-set-up.md
+++ b/getting-started/environment-set-up.md
@@ -53,7 +53,7 @@ This is what your console should look like after running the command:
 ```bash
 {
   "name": "hello-hedera-js-sdk",
-  "version": "",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -481,5 +481,7 @@ func main() {
 
 
 {% hint style="info" %}
-Have a question? [Ask it on StackOverflow](https://stackoverflow.com/questions/tagged/hedera-hashgraph)
+Have a question? [Ask it on StackOverflow  "version": "",
+57
+](https://stackoverflow.com/questions/tagged/hedera-hashgraph)
 {% endhint %}

--- a/getting-started/environment-set-up.md
+++ b/getting-started/environment-set-up.md
@@ -59,6 +59,7 @@ This is what your console should look like after running the command:
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "keywords": [],
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
**Description**:
re: https://docs.hedera.com/hedera/getting-started/environment-set-up

Super nit picky, but it is important to keep docs up-to-date so they don't drift, so :shrug:.

This PR updates the example of an `npm init` output to include a default version of 1.0.0 and an empty `keywords` array. The current example shows an empty string. https://docs.hedera.com/hedera/getting-started/environment-set-up

Current:
![image](https://github.com/hashgraph/hedera-docs/assets/1504756/d434b550-118d-4823-bbac-952dde9bf197)

Actual:
![image](https://github.com/hashgraph/hedera-docs/assets/1504756/669851f6-e4d4-4532-aebe-7fd77428fd06)