### PR TITLE
Update environment-set-up.md - Fix broken Node.js example (require dotenv)

### DIFF
--- a/getting-started/environment-set-up.md
+++ b/getting-started/environment-set-up.md
@@ -198,6 +198,7 @@ public class HederaExamples {
 {% code title="index.js" %}
 ```javascript
 const { Client, PrivateKey, AccountCreateTransaction, AccountBalanceQuery, Hbar, TransferTransaction } = require("@hashgraph/sdk");
+require('dotenv').config();
 
 async function environmentSetup() {
 


### PR DESCRIPTION
**Description**:

re: https://docs.hedera.com/hedera/getting-started/environment-set-up

This PR fixes the NodeJS JavaScript example. The example pulls in the `dotenv` dependency but the code never requires it: 

Before:
![image](https://github.com/hashgraph/hedera-docs/assets/1504756/211d08f3-6785-42b5-a32a-4f15406f1456)

After:
![image](https://github.com/hashgraph/hedera-docs/assets/1504756/38a0f544-286c-434b-a71c-0ae41368805e)


=========================


![image](https://github.com/hashgraph/hedera-docs/assets/1504756/23cb7021-7867-42f5-9d43-de781122afd1)
![image](https://github.com/hashgraph/hedera-docs/assets/1504756/4c69893d-7bb3-45b9-ad59-86cf983cd9aa)
