### PR TITLE
Add prepare-commit-msg hook to auto --signoff on commits

### DIFF
--- a/hooks-git/prepare-commit-msg
+++ b/hooks-git/prepare-commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This hook is invoked by git commit right after preparing the default log 
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+# This adds a "Signed-off-by: Name <email>" line to the message, if it isn't 
+# already there.  It is equivalent to using `git commit --signoff`. The real name and email are used if they are set in the
+# git config variables user.name and user.email.  The email is taken only from
+# the git config variable user.email, and not from the local part of the
+# "author" or "committer" identities; if you want to add a "From: " or
+# "Reply-To: " header to the message, do that in a custom prepare-commit-msg
+# hook.
+SOB=$(git var GIT_COMMITTER_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+git interpret-trailers --in-place --trailer "$SOB" "$COMMIT_MSG_FILE"
+if test -z "$COMMIT_SOURCE"
+then
+  /usr/bin/perl -i.bak -pe 'print "\n" if !$first_line++' "$COMMIT_MSG_FILE"
+fi


### PR DESCRIPTION
This PR:

1. Adds a hooks-git directory
2. Adds a prepare-commit-msg hook, that was initially copied from .git/hooks/prepare-commit-msg.sample
  - When a commit message is prepared it will add the `--signoff` automatically

TODO:
1. Needs to be added to README.md OR support-and-community/contributing-guide.md with the command to install it:
  - `cp hooks-git/prepare-commit-msg .git/hooks && chmod +x .git/hooks/prepare-commit-msg`
  - There is no way to automate this on a clone or pull due to security risks, there must be a manual installation command that is run by the user
  
  
Test:
 1. Checkout this PR e.g. `gh pr checkout https://github.com/hashgraph/hedera-docs/pull/381`
 2. Run `cp hooks-git/prepare-commit-msg .git/hooks && chmod +x .git/hooks/prepare-commit-msg`
 3. Test commit with `git commit --allow-empty --message "test auto --signoff"`
 4. Verify with `git log -1` and you should see the last commit message with the Signoff at the bottom of the commit message