### PR TITLE
docs: add hscs workshop - index page + setup only

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -18,6 +18,8 @@
     * [Deploy a Subgraph Using The Graph and JSON-RPC](tutorials/smart-contracts/deploy-a-subgraph-using-the-graph-and-json-rpc.md)
     * [How to Set Up Foundry to Test Smart Contracts on Hedera](tutorials/smart-contracts/how-to-set-up-foundry-to-test-smart-contracts-on-hedera.md)
     * [Deploy Smart Contracts on Hedera Using Truffle](tutorials/smart-contracts/deploy-smart-contracts-on-hedera-using-truffle.md)
+    * [Hedera Smart Contracts Workshop](tutorials/smart-contracts/hscs-workshop/README.md)
+      * [Setup](tutorials/smart-contracts/hscs-workshop/setup.md)
   * [Consensus](tutorials/consensus/README.md)
     * [Submit Your First Message](tutorials/consensus/submit-your-first-message.md)
     * [Submit Message to Private Topic](tutorials/consensus/submit-message-to-private-topic.md)

--- a/tutorials/smart-contracts/hscs-workshop/README.md
+++ b/tutorials/smart-contracts/hscs-workshop/README.md
@@ -1,0 +1,96 @@
+---
+description: >-
+  Hedera Smart Contract Service workshop.
+  Smart contracts are a means to enable custom logic and processing in a DLT.
+  Developers can harness their power to build their own decentralised applications (DApps).
+  Learn how to get started with the Hedera Smart Contract Service (HSCS) in this workshop. 
+---
+
+# Hedera Smart Contracts Workshop
+
+Smart contracts are a means to enable custom logic and processing in a DLT. Developers can harness their power to build their own decentralised applications (DApps). Learn how to get started with the Hedera Smart Contract Service (HSCS) in this workshop. 
+
+## What we will cover
+
+- Syntax of Solidity, a programming language used to write smart contracts
+- Using the Solidity compiler
+- Using Hedera SDK JS to deploy smart contracts onto Hedera networks
+- Using Hedera SDK JS to interact with smart contracts on Hedera networks
+- Using Hardhat + EthersJs to deploy smart contracts onto Hedera networks
+- Using Hardhat + EthersJs to interact with smart contracts on Hedera networks
+- Where to go from here
+
+## Prerequisites
+
+Prior knowledge:
+
+- Javascript syntax
+- Hedera network core concepts
+
+System setup:
+
+- `git` installed
+	- Minimum version: 2.37
+	- [Install Git (Github)](https://github.com/git-guides/install-git)
+- NodeJs + `npm` installed
+	- Minimum version of NodeJs: 18
+	- Recommended for Linux & Mac: [`nvm`](https://github.com/nvm-sh/nvm)
+	- Recommended for Windows: [`nvm-windows`](https://github.com/coreybutler/nvm-windows)
+- POSIX-compliant shell
+	- For Linux & Mac: The shell that ships with the operating system will work. Either `bash` or `zsh` will work.
+	- For Windows: The shell that ships with the operating system (`cmd.exe`, `powershell.exe`) will *not* work. Recommended alternatives: WSL/2, or git-bash which ships with git-for-windows.
+- Google chrome installed: [Chrome](https://www.google.com/chrome/)
+- Internet connection
+
+Optional system setup:
+
+- `jq`
+	- For Linux: Use OS package manager
+	- For Mac: `brew install jq`
+	-  For Windows: Install `.exe` file manually: [JQ releases (Github)](https://github.com/jqlang/jq/releases)
+
+## Software libraries and developer tools
+
+Before we begin coding,
+let's take a look at the various software libraries and developer tools that
+you will need to be familiar with when working with smart contracts on HSCS.
+
+[Hedera SDK JS](https://github.com/hashgraph/hedera-sdk-js)
+is a software library that contains functions designed to interact the all
+of the services available on the Hedera network:
+HCS, HTS, HFS, and HSCS.
+That includes smart contracts.
+
+Both [EthersJs](https://docs.ethers.org/v5/)
+and [Web3Js](https://web3js.readthedocs.io/en/v1.10.0/)
+are software libraries that contain functions designed to interact with
+the Ethereum network, and any other EVM-compatible networks.
+This means that you can use them to interact with HSCS as well
+(but not with HCS, HTS, or HFS).
+
+
+We've already seen some Solidity syntax,
+but we cannot just take the Solidity code and ask HSCS,
+or any other EVM implementation for that matter, to run it.
+Instead we need [`solc`](https://docs.soliditylang.org/en/v0.8.19/),
+the Solidity compiler, to compile it into EVM bytecode,
+which can then be executed by any EVM implementation,
+including the one in HSCS.
+
+Worth pointing out that Solidity is not the only game in town.
+You can actually write smart contracts in any language,
+as long as it compiled to EVM bytecode.
+The most popular alternative smart contract programming language is
+[Vyper](https://docs.vyperlang.org/en/stable/).
+
+In this workshop we will be using **Solidity**.
+
+[Truffle Suite](https://trufflesuite.com/),
+[Hardhat](https://hardhat.org/),
+and [Foundry](https://getfoundry.sh/)
+are developer frameworks that are designed to make it easier to
+work with smart contract development workflows
+by providing various utilities, scripts, structure, and documentation
+that are useful during development.
+
+In this workshop we will be using **Hardhat**.

--- a/tutorials/smart-contracts/hscs-workshop/setup.md
+++ b/tutorials/smart-contracts/hscs-workshop/setup.md
@@ -1,0 +1,259 @@
+---
+description: >-
+  Setup tutorial - Hedera Smart Contract Service workshop.
+  Smart contracts are a means to enable custom logic and processing in a DLT.
+  Developers can harness their power to build their own decentralised applications (DApps).
+  Learn how to get started with the Hedera Smart Contract Service (HSCS) in this workshop. 
+---
+
+# Setup - Hedera Smart Contracts Workshop
+
+## Set up the project
+
+The setup has already been (mostly) done. All that's left for you to do is clone the [accompanying tutorial GitHub repository](https://github.com/hedera-dev/hedera-smart-contracts-workshop) and install the dependencies:
+
+```sh
+git clone -b main git@github.com:hedera-dev/hedera-smart-contracts-workshop.git
+cd hedera-smart-contracts-workshop
+```
+
+{% hint style="info" %}
+If you do not have SSH available on your system, or are unable to configure it for GitHub, you may wish to try this git command instead:
+
+`git clone -b main https://github.com/hedera-dev/hedera-smart-contracts-workshop.git`
+{% endhint %}
+
+## Configuration
+
+### Step B1: Environment variables file
+
+In the root directory of the repo, you will find a file named `.env.example`.
+Make a copy of this file, and name it `.env`.
+
+```shell
+cp .env.example .env
+```
+
+### Step B2: Operator account
+
+An operator account is used to obtain an initial sum of HBAR on Hedera Testnet,
+and then use that to pay for various Hedera network operations.
+This includes everything from basic transactions, to gas fees for HSCS interactions.
+
+Visit the [Hedera Portal](https://portal.hedera.com/) to get started.
+
+* (1) Create a Testnet account.
+
+<figure>
+	<img src="https://i.stack.imgur.com/tgkvS.png" alt="" width="375">
+	<figcaption>Hedera Portal  - Create Testnet Account</figcaption>
+</figure>
+
+* (2) Copy-paste the confirmation code sent to your email.
+
+<figure>
+	<img src="https://i.stack.imgur.com/4H9XT.png" alt="" width="375">
+	<figcaption>Hedera Portal - Email Verification</figcaption>
+</figure>
+
+* (3) Fill out this form with details for your profile.
+
+<figure>
+	<img src="https://i.stack.imgur.com/atW69.png" alt="" width="375">
+	<figcaption>Hedera Portal - Profile Details</figcaption>
+</figure>
+
+* (4) In the top-left there is a drop down menu, select between Hedera Testnet (default) and Previewnet:
+
+<figure>
+	<img src="https://i.stack.imgur.com/2A2ua.png" alt="" width="563">
+	<figcaption>Hedera Portal - Select Network</figcaption>
+</figure>
+
+* (5) From the next screen that shows your accounts, copy the value of the "**DER-encoded private key**" and replace `OPERATOR_KEY` in the `.env` file with it.
+
+<figure>
+	<img src="https://i.stack.imgur.com/MrBx0.png" alt="" width="563">
+	<figcaption>Hedera Portal - Account Details</figcaption>
+</figure>
+
+* (6) From the same screen, copy the value of "**Account ID**" and replace the value of the `OPERATOR_ID` variable in the `.env` file with it.
+
+### Step B3: Seed phrase
+
+When developing smart contracts, you often need more than 1 account to do so.
+Thankfully we do not need to go through the somewhat cumbersome process
+of creating multiple accounts via the Hedera Portal -
+you only really need to do that once for the operator account.
+
+Any subsequent accounts that you wish to create can be generated programmatically,
+and funded with HBAR from your operator account.
+
+To do so, we will utilise something called a **seed phrase**,
+which is a sequence of selected dictionary words chosen at random.
+This process is defined in BIP-39.
+
+Subsequently, we will use that seed phrase as an input and generate multiple accounts;
+each of which consists of a private key, a public key, and an address.
+This process is defined in BIP-44.
+
+{% hint style="info" %}
+- "BIP" stands for Bitcoin Improvement Proposal.
+- "EIP" stands for Ethereum Improvement Proposal, and was preceded by "ERC" which stands for Ethereum Request for Comments.
+- "HIP" stands for Hedera Improvement Proposal.
+{% endhint %}
+
+Interestingly these 2 BIPs were never adopted by the Bitcoin community,
+but are almost de-facto used by everyone in the Ethereum community.
+On Hedera, you can use these 2 BIPs to generate Hedera EVM accounts,
+but this is not possible for Hedera-native accounts
+(as they use a different type of public key algorithm).
+
+{% hint style="info" %}
+ECDSA (Elliptic Curve Digital Signing Algorithm) is a public key algorithm, and secp256k1 is a particular configuration that may be used by the ECDSA algorithm.  
+  
+EdDSA (Edwards Digital Signing Algorithm) is another public key algorithm, and Ed25519 is a particular configuration that may be used by the EdDSA algorithm.
+
+Both Bitcoin and Ethereum use ECDSA with secp256k1 for their accounts.
+
+Hedera native accounts use EdDSA with Ed25519,
+and Hedera EVM accounts use ECDSA with secp256k1.
+{% endhint %}
+
+Enough theory - let's generate a seed phrase!
+
+Visit [`iancoleman.io/bip39`](https://iancoleman.io/bip39/),
+and you can generate your seed phrase there.
+
+Copy these words, and replace the value of the `BIP39_SEED_PHRASE` variable
+in the `.env` file with this.
+
+[Ref: BIP-39 Mnemonic code for generating deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+
+[Ref: BIP-44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+
+### Step B4: Fund several Hedera EVM accounts
+
+At this point, you have an operator account, which is already funded with HBAR,
+and you have a seed phrase.
+Let's generate more accounts based on the seed phrase ,
+and then transfer HBAR to them from the operator account.
+
+First switch to the `intro` directory, and install dependencies using npm.
+
+```
+cd ./intro
+npm install
+```
+
+Next, let's use a script already prepared for you.
+We want this script to generate 2 Hedera EVM accounts,
+and transfer 100 HBAR to each of them,
+so let's set those values in `generate-evm-accounts.js`.
+
+```javascript
+const NUM_ACCOUNTS = 2;
+const AMOUNT_PER_ACCOUNT = 100;
+const HD_PATH = "m/44'/60'/0'/0";
+```
+
+{% hint style="info" %}
+Above, we're using `m/44'/60'/0'/0` as the derivation path.
+This is the Ethereum derivation path, and we need it because Metamask
+hardcodes this value as a constant, and does not allow it to be configured.
+{% endhint %}
+
+Run this script.
+
+```shell
+node ./generate-evm-accounts.js
+```
+
+This should output something similar to the following:
+
+```text
+EVM account #0 generated.
+#0     HD path: m/44'/60'/0'/0/0
+#0 Private key: 3030020100300706052b8104000a04220420fb11afc5d508036ac7a9df9f1eb7cea551e4a7b738c2c70da099fe5f379f3364
+#0  Public key: 302d300706052b8104000a032200027a753c29cc9f0ea0b6ccf0614676daeba3da0dbd5f54ef9850ad3878ded4e077
+#0 EVM address: 07ffaadfe3a598b91ee08c88e5924be3eff35796
+EVM account #1 generated.
+#1     HD path: m/44'/60'/0'/0/1
+#1 Private key: 3030020100300706052b8104000a042204206e3ff9f1f1ae58248a5838ec877acc55d103009586224d76ab74a652d408cf12
+#1  Public key: 302d300706052b8104000a03220002c4c2ed7a682a601c9c61dec42e87442b63893a6e5efdf6dc327a4b3bcc62aba9
+#1 EVM address: 1c29e31d241f0d06f3763221f5224a6b82f09cce
+EVM account #2 generated.
+#2     HD path: m/44'/60'/0'/0/2
+#2 Private key: 3030020100300706052b8104000a042204203ccfcb41922c242e955cdba0245c3cddc88c45ea84eab4f2a0416a7978b2f897
+#2  Public key: 302d300706052b8104000a03220002fa66a7e8c206f1678457524690011a1deedbea413eadec83cf7d2cb1d3b6fece
+#2 EVM address: 9a814b5afd6b0fff1e9548dcba4d09cdd8c81568
+EVM account #3 generated.
+#3     HD path: m/44'/60'/0'/0/3
+#3 Private key: 3030020100300706052b8104000a0422042054c156c865a054c6134a1bd282d6803f60763326c3293fbea33853919532e2e2
+#3  Public key: 302d300706052b8104000a03220002cb32b5529854dc2c754b8c365d6060de0cb8a209aab44fedf4e74efa74460fcd
+#3 EVM address: a80eb8ed3c3c78bee1de8391f89ddd6873bf695d
+Transfer transaction ID 0.0.3996280@1690161480.080071857
+```
+
+### Check funding of EVM accounts on Hashscan
+
+Copy the transaction ID from (the final line of) the output from the previous step,
+and visit Hashscan, and search for that ID.
+You should get to a "Transaction" page,
+e.g. `https://hashscan.io/testnet/transaction/1689772989.212011003`.
+
+Scroll down to the "Transfers" section,
+which should graphically depict the flow of HBAR between various accounts.
+In this case `-400` (and a fractional amount of `-0.00185217`)
+from the operator account,
+`+100.00000000` to each of the 4 EVM accounts,
+and fractional amounts to a couple of other accounts to pay for transaction processing.
+(Note that the fractional amounts may vary, they won't necessarily be `0.00185217` as above.)
+
+Now you should have 1 Hedera-native account (previously funded),
+plus 4 new EVM accounts (freshly funded).
+
+### Address formats
+
+Hedera networks have a native account address format,
+called the *Account ID*.
+An example of this would be: `0.0.3996280`.
+
+Hedera also supports EVM account address formats.
+This has 2 variants:
+
+The *EVM Address Alias*.
+An example of this would be: `0x7394111093687e9710b7a7aeba3ba0f417c54474`.
+This is sometimes referred to as the *non-long-zero* address.
+
+The *Account Num Alias*.
+An example of this would be: `0x00000000000000000000000000000000003cfa78`.
+This is sometimes referred to as the *long-zero* address.
+
+Finally Hedera also supports a *Key Alias*,
+and this is something that you're unlikely to encounter in most situations.
+
+While you may choose to interact with the Hedera network using any of the address formats,
+when interacting with smart contracts, the *EVM Address Alias* is the most useful,
+as that is what is visible and understood by smart contracts when they are invoked.
+
+[Ref: HIP-583 - Expand alias support in CryptoCreate & CryptoTransfer Transactions](https://hips.hedera.com/hip/hip-583)
+
+[Ref: hedera-code-snippets - Convert address from Hedera-native (`S.R.N`) format to EVM (`0x...`) format](https://github.com/hedera-dev/hedera-code-snippets/tree/main/convert-hedera-native-address-to-evm-address)
+
+[Ref: Stackoverflow - How to convert a Hedera native address into a non-long-zero EVM address?](https://stackoverflow.com/q/76680532/194982)
+
+### Step B5: RPC endpoint
+
+For this step, you have a choice:
+
+- Run your own Hedera RPC Relay server: [Configuring Hedera JSON-RPC Relay endpoints](https://docs.hedera.com/hedera/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay)
+- Use an RPC service provider, Arkhia: [Configuring Arkhia RPC endpoints](https://docs.hedera.com/hedera/tutorials/more-tutorials/json-rpc-connections/arkhia)
+
+Copy these words, and replace the value of the `BIP39_SEED_PHRASE` variable
+in the `.env` file with this.
+
+Whichever method you choose,
+obtain the JSON-RPC URL for Hedera Testnet,
+and replace the value of the `RPC_URL_HEDERATESTNET` variable
+in the `.env` file with this.


### PR DESCRIPTION
**Description**:

This PR a a new HSCS workshop to the tutorials section:

* index page
* setup page

Not yet included in this PR:

* solidity page
* hedera sdk js page
* hardhat page
* outro page

**Related issue(s)**:

* based on: https://github.com/hedera-dev/hedera-smart-contracts-workshop/
* discussion: https://swirldslabs.slack.com/archives/C040CSLT7M0/p1690187855884669

**Notes for reviewer**:

* more pages (as indicated in the description) will be added in subsequent PRs
* this was run as a 2 hour live workshop as part of an (external) hackathon, and the video recording from that may be clipped into smaller segments and placed into each of these pages

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
