### PR TITLE
fix: minor - update link to faucet

### DIFF
--- a/getting-started/introduction.md
+++ b/getting-started/introduction.md
@@ -10,7 +10,7 @@ Through this short _Getting Started_ series, you will learn the basics of creati
 
 ### Hedera Faucet
 
-The Hedera faucet allows you to anonymously receive testnet HBAR without the hassle of creating a developer portal account. To use the anonymous faucet, visit the [Hedera faucet](https://dev.portal.hedera.com/faucet) and connect your wallet, or enter an EVM wallet address or Hedera account ID to initiate the process.&#x20;
+The Hedera faucet allows you to anonymously receive testnet HBAR without the hassle of creating a developer portal account. To use the anonymous faucet, visit the [Hedera faucet](https://portal.hedera.com/faucet) and connect your wallet, or enter an EVM wallet address or Hedera account ID to initiate the process.&#x20;
 
 <figure><img src="../.gitbook/assets/faucet-receive-hbar.png" alt=""><figcaption></figcaption></figure>
 


### PR DESCRIPTION
**Description**:

## What

- Update link `dev.portal.hedera.com/faucet` --> `portal.hedera.com/faucet`

## Why

- Still pointing to the staging link, should point to the live link instead

## Refs

- https://hedera.com/blog/introducing-a-new-testnet-faucet-and-hedera-portal-changes

**Related issue(s)**:

Fixes: N/A

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.) -- manually
