### PR TITLE
docs: minor - update hello world sequences

### DIFF
--- a/tutorials/hello-world/README.md
+++ b/tutorials/hello-world/README.md
@@ -2,13 +2,13 @@
 
 ## Hedera Quickstart Guide
 
-So, you want to develop on Hedera but are unsure where to start? Why not start with something you could complete in 10 minutes? This quick start guide is designed to kickstart your Hedera development journey.&#x20;
+So, you want to develop on Hedera but are unsure where to start? Why not start with something you could complete in 10 minutes? This quick start guide is designed to kickstart your Hedera development journey.
 
 Let's begin!
 
 ## Hello World Sequences
 
-There are multiple Hello World sequences for you to follow along. To start, you **must** complete the first sequence, as you will need a **funded account** to do any other tasks on Hedera.&#x20;
+There are multiple Hello World sequences for you to follow along. To start, you **must** complete the first sequence, as you will need a **funded account** to do any other tasks on Hedera.
 
 <table data-view="cards"><thead><tr><th align="center"></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td align="center"><p><strong>START HERE</strong></p><p>⬇</p><p><a href="create-fund-account.md"><strong>Create &#x26; fund account</strong></a></p></td><td><a href="../../.gitbook/assets/create-an-account-icon.png">create-an-account-icon.png</a></td><td><a href="create-fund-account.md">create-fund-account.md</a></td></tr></tbody></table>
 

--- a/tutorials/hello-world/create-fund-account.md
+++ b/tutorials/hello-world/create-fund-account.md
@@ -163,12 +163,12 @@ mnemonics@1.1.3
 Ok to proceed? (y)
 ```
 
-This seed phrase, will be used to generate the cryptographic keys for the accounts that you are about to create.
+This seed phrase will be used to generate the cryptographic keys for the accounts that you are about to create.
 {% endhint %}
 
 Copy the seed phrase. Replace `SEED_PHRASE` in the `.env` file with it. The file contents should now look similar to this:
 
-{% code title=".env" overflow="wrap" lineNumbers="false" %}
+{% code title=".env" overflow="wrap" %}
 ```shell
 SEED_PHRASE="artefact gasp crop double silk grid visual gather argue glow melody net"
 ACCOUNT_PRIVATE_KEY=YOUR_HEX_ENCODED_PRIVATE_KEY
@@ -203,7 +203,7 @@ For example, the comment for **Step 1** looks like this:
 
 The `ethersHdNode` module has been imported from [EthersJs](https://docs.ethers.org/v5/). This takes a seed phrase as input, and outputs a private key. To do so, invoke the `fromMnemonic()` method and pass in `process.env.SEED_PHRASE` as the parameter:
 
-{% code title="script-create-fund-account.js" overflow="wrap" lineNumbers="false" %}
+{% code title="script-create-fund-account.js" overflow="wrap" %}
 ```javascript
     const hdNodeRoot = ethersHdNode.fromMnemonic(process.env.SEED_PHRASE);
 ```
@@ -224,7 +224,7 @@ The `hdNodeRoot` instance is subsequently used to generate the private keys.
 
 A `privateKey` instance has been initialized. This requires no further input to derive an EVM address - read its `publicKey` property, and then invoke its `toEvmAddress` method:
 
-{% code title="script-create-fund-account.js" overflow="wrap" lineNumbers="false" %}
+{% code title="script-create-fund-account.js" overflow="wrap" %}
 ```javascript
     const evmAddress = `0x${privateKey.publicKey.toEvmAddress()}`;
 ```
@@ -254,7 +254,7 @@ Note that `accountId` and `accountBalanceHbar` are both `undefined`, because gen
 
 Copy the value of `privateKeyHex`. Replace `YOUR_HEX_ENCODED_PRIVATE_KEY` in the `.env` file with it. The file contents should now look similar to this:
 
-{% code title=".env" overflow="wrap" lineNumbers="false" %}
+{% code title=".env" overflow="wrap" %}
 ```shell
 SEED_PHRASE="artefact gasp crop double silk grid visual gather argue glow melody net"
 ACCOUNT_PRIVATE_KEY=0x0ac20a3c1573ba9a5c6c69349fa51f40bd502cf250e226a7100869338f15aae2
@@ -308,7 +308,7 @@ A success dialog will pop up.
 
 Replace `YOUR_ACCOUNT_ID` in the `.env` file with it. The file contents should now look similar to this:
 
-{% code title=".env" overflow="wrap" lineNumbers="false" %}
+{% code title=".env" overflow="wrap" %}
 ```shell
 SEED_PHRASE="artefact gasp crop double silk grid visual gather argue glow melody net"
 ACCOUNT_PRIVATE_KEY=0x0ac20a3c1573ba9a5c6c69349fa51f40bd502cf250e226a7100869338f15aae2
@@ -320,7 +320,6 @@ RPC_URL=YOUR_JSON_RPC_URL
 {% hint style="info" %}
 You may have noticed that `RPC_URL` is unused throughout. This is intentional - as it will be used in some of the other Hello World sequences, so be sure to check them out after completing this one!
 {% endhint %}
-
 
 Refresh the page in your browser (navigated to `accountExplorerUrl` from earlier). This time you should see:
 
@@ -407,4 +406,4 @@ Note that the branch names are delimited by `..`, and not by `...`, as the latte
 
 ***
 
-**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**:[ Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)
+**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**: [Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)

--- a/tutorials/hello-world/hfs-files.md
+++ b/tutorials/hello-world/hfs-files.md
@@ -55,7 +55,7 @@ pwd
 
 This should output a path that ends with `/hello-future-world/01-hfs-files-sdk`. If not, you will need to start over.
 
-```
+```text
 /some/path/hello-future-world/01-hfs-files-sdk
 ```
 
@@ -67,7 +67,7 @@ ls -a
 
 The first few line of the output should look display `.env`. If not, you'll need to start over.
 
-```
+```text
 .
 ..
 .env
@@ -103,9 +103,11 @@ The contents of `my-file.txt` have been read from disk and stored in a `Buffer` 
 
 Set the contents of `localFileContents` in `FileCreateTransaction`, to write your file onto Hedera Testnet.
 
+{% code title="script-hfs-files-sdk.js" overflow="wrap" %}
 ```js
         .setContents(localFileContents.toString())
 ```
+{% endcode %}
 
 ### Step 2: File contents query
 
@@ -113,9 +115,11 @@ After the `FileCreateTransaction` has been executed, the response will contain a
 
 Set the file ID in `FileContentsQuery`.
 
+{% code title="script-hfs-files-sdk.js" overflow="wrap" %}
 ```js
         .setFileId(fileId);
 ```
+{% endcode %}
 
 ***
 
@@ -129,7 +133,7 @@ node script-hfs-files-sdk.js
 
 You should see output similar to the following:
 
-```
+```text
 fileId: 0.0.5835692
 fileCreateTxId: 0.0.1186@1699277862.561525871
 txExplorerUrl: https://hashscan.io/testnet/transaction/0.0.1186@1699277862.561525871
@@ -143,10 +147,10 @@ To verify that both the `FileCreateTransaction` and `FileContentsQuery` have wor
 
 Open `txExplorerUrl` in your browser and check that:
 
-* The transaction exists
-* The "type" is shown as "FILE CREATE"
-
 <img src="../../.gitbook/assets/hello-world--hfs--transaction.drawing.svg" alt="HFS transaction in Hashscan, with annotated items to check." class="gitbook-drawing">
+
+* The transaction exists **(1)**
+* The "type" is shown as "FILE CREATE" **(2)**
 
 ***
 
@@ -197,4 +201,4 @@ Note that the branch names are delimited by `..`, and not by `...`, as the latte
 
 ***
 
-**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**:[ Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)
+**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**: [Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)

--- a/tutorials/hello-world/hscs-smart-contract.md
+++ b/tutorials/hello-world/hscs-smart-contract.md
@@ -58,7 +58,7 @@ pwd
 
 This should output a path that ends with `/hello-future-world/03-hscs-smart-contract-ethersjs`. If not, you will need to start over.
 
-```
+```text
 /some/path/hello-future-world/03-hscs-smart-contract-ethersjs
 ```
 
@@ -70,7 +70,7 @@ ls -a
 
 The first few line of the output should look display `.env`. If not, you'll need to start over.
 
-```
+```text
 .
 ..
 .env
@@ -91,14 +91,14 @@ npm install --global solc@0.8.17
 ```
 
 {% hint style="info" %}
-[Solidity](https://docs.soliditylang.org/) is a programming language that was designed specifically for writing smart contracts in. The Solidity compiler outputs bytecode that can be run by an [Ethereum Virtual Machine (EVM)](https://ethereum.org/en/developers/docs/evm/) implementation.
+[Solidity](https://docs.soliditylang.org/) is a programming language that was designed specifically for writing smart contracts in. The Solidity compiler outputs bytecode that can be run by an [Ethereum Virtual Machine (EVM)](https://ethereum.org/en/developers/docs/evm/) implementation; including Hyperledger Besu's EVM, which powers Hedera Smart Contract Service.
 {% endhint %}
 
 {% hint style="info" %}
 Note that although the `npm` package is named `solc`, the executable exposed on your command line is named `solcjs`.
 {% endhint %}
 
-Then, open both these files in a code editor, such as VS Code.
+Then, open both of the following files in a code editor, such as VS Code.
 
 * `my_contract.sol`
 * `script-hscs-smart-contract-ethersjs.js`
@@ -113,9 +113,11 @@ An almost-complete smart contract has already been prepared for you, `my_contrac
 
 Within the `greet()` function, we would like to access the `names` mapping and retrieve the name of the account that is invoking this function. The account is identified by its EVM account alias, which is available as `msg.sender` within the Solidity code.
 
-```js
+{% code title="my_contract.sol" overflow="wrap" %}
+```solidity
         string memory name = names[msg.sender];
 ```
+{% endcode %}
 
 {% hint style="info" %}
 _**Note**: This smart contract has two functions, `introduce` and `greet`. You will invoke both of them later on._
@@ -127,7 +129,7 @@ _**Note**: This smart contract has two functions, `introduce` and `greet`. You w
 
 Once you have completed writing the smart contract in Solidity, you will need to compile it using the Solidity compiler installed earlier.
 
-Invoke the compiler on your Solidity file. Then, list files in the current directory.
+Invoke the compiler on your Solidity file. Then list files in the current directory.
 
 ```shell
 solcjs --bin --abi ./my_contract.sol
@@ -136,7 +138,7 @@ ls
 
 You should see an output similar to the following:
 
-```
+```text
 my_contract.sol
 my_contract_sol_MyContract.abi
 my_contract_sol_MyContract.bin
@@ -172,23 +174,25 @@ Now, you should see the project details.
 * Copy the "JSON-RPC" field.
 * In the "Security" section, copy the "API Key" field.
 
-In the `.env` file, edit the property with the key `RPC_URL`, replacing `YOUR_JSON_RPC_URL` with the "JSON-RPC" value, followed by `/`, and finally, the "API key" value that you have just copied.
+In the `.env` file, edit the property with the key `RPC_URL`, to replace `YOUR_JSON_RPC_URL` with the "JSON-RPC" value, followed by a `/` character, and finally, the "API key" value that you have just copied.
 
-For example, if the API key field is `ABC123`, and the JSON-RPC field is `https://pool.arkhia.io/hedera/testnet/json-rpc/v1`, the line in your `.env` file should look like this:
+For example, if the JSON-RPC field is `https://pool.arkhia.io/hedera/testnet/json-rpc/v1`, and if the API key field is `ABC123`, the line in your `.env` file should look like this:
 
-```
+{% code title=".env" overflow="wrap" %}
+```shell
 RPC_URL=https://pool.arkhia.io/hedera/testnet/json-rpc/v1/ABC123
 ```
+{% endcode %}
 
 {% hint style="warning" %}
-**Note**: Ensure that you have a **`/`** just before the API key.&#x20;
+**Note**: Ensure that you have a **`/`** just before the API key.
 {% endhint %}
 
 <details>
 
 <summary>Alternative RPC configuration</summary>
 
-Arkhia is one of several different options for JSON-RPC connections. This tutorial covers all of the different options: [How to Connect to Hedera Networks Over RPC](https://docs.hedera.com/hedera/tutorials/more-tutorials/json-rpc-connections).
+Arkhia is one of multiple options for JSON-RPC connections. This tutorial covers the available options: [How to Connect to Hedera Networks Over RPC](https://docs.hedera.com/hedera/tutorials/more-tutorials/json-rpc-connections).
 
 </details>
 
@@ -202,10 +206,12 @@ An almost complete script has already been prepared for you, `script-hscs-smart-
 
 Initialize an instance of `ContractFactory` from EthersJs.
 
+{% code title="script-hscs-smart-contract-ethersjs.js" overflow="wrap" %}
 ```js
     const myContractFactory = new ContractFactory(
         abi, evmBytecode, accountWallet);
 ```
+{% endcode %}
 
 {% hint style="info" %}
 **Note**: The `ContractFactory` class is used to prepare a smart contract for deployment. To do so, pass in the ABI and bytecode output by the Solidity compiler earlier. Also, pass in the `accountWallet` object, which is used to authorize transactions and is needed for the deployment transaction.
@@ -217,19 +223,23 @@ Upon preparation, it sends a deployment transaction to the network, and an insta
 
 The `introduce` function requires a single parameter of type `string`, and changes the state of the smart contract to store this value. Enter your name (or nickname) as the parameter. For example, if you wish to use "bguiz", the invocation should look like this:
 
+{% code title="script-hscs-smart-contract-ethersjs.js" overflow="wrap" %}
 ```js
     const myContractWriteTxRequest = await myContract.functions.introduce('bguiz');
 ```
+{% endcode %}
 
 ### Step 4: Invoke a smart contract query
 
-In the previous step, you changed some state of the smart contract, which involved submitting a transaction to the network. This time, you are going to read some state of the smart contract. This is much simpler to do as no transaction is needed.
+In the previous step, you **changed** some state of the smart contract, which involved submitting a transaction to the network. This time, you are going to **read** some state of the smart contract. This is much simpler to do as no transaction is needed.
 
 Invoke the `greet` function and save its response to a variable, `myContractQueryResult`. This function does not take any parameters.
 
+{% code title="script-hscs-smart-contract-ethersjs.js" overflow="wrap" %}
 ```js
     const [myContractQueryResult] = await myContract.functions.greet();
 ```
+{% endcode %}
 
 {% hint style="info" %}
 When invoking functions in a smart contract, you may do so in two different ways:
@@ -250,7 +260,7 @@ node script-hscs-smart-contract-ethersjs.js
 
 You should see output similar to the following:
 
-```
+```text
 accountId: 0.0.1201
 accountAddress: 0x7394111093687e9710b7a7aEBa3BA0f417C54474
 accountExplorerUrl: https://hashscan.io/testnet/address/0x7394111093687e9710b7a7aEBa3BA0f417C54474
@@ -263,23 +273,23 @@ myContractQueryResult: Hello future - bguiz
 
 Open `myContractExplorerUrl` in your browser and check that:
 
-1. The contract exists
-2. Under the "Contract Bytecode" section, its "Compiler Version" field matches the version of the Solidity compiler that you used (`0.8.17`)
-3. Under the "Recent Contract Calls" section, There should be _two_ transactions:
-   * (**3A**) The transaction with the earlier timestamp (bottom) should be the deployment transaction.
+<img src="../../.gitbook/assets/hello-world--hscs--contract.drawing.svg" alt="HSCS contract in Hashscan, with annotated items to check." class="gitbook-drawing">
+
+* The contract exists
+* Under the "Contract Bytecode" section, its "Compiler Version" field matches the version of the Solidity compiler that you used (`0.8.17`) **(2)**
+* Under the "Recent Contract Calls" section, There should be _two_ transactions:
+   * The transaction with the *earlier timestamp* (bottom) should be the *deployment* transaction. **(3A)**
      * Navigate to this transaction by clicking on the timestamp.
      * Under the "Contract Result" section, the "Input - Function & Args" field should be a _relatively long_ set of hexadecimal values.
      * This is the EVM bytecode output by the Solidity compiler.
      * Navigate back to the Contract page (browser `⬅` button).
-   * (**3B**) The transaction with the later timestamp (top) should be the transaction in which the `introduce` function was invoked.
+   * The transaction with the *later timestamp* (top) should be the *function invocation* transaction, of the `introduce` function. **(3B)**
      * Navigate to this transaction by clicking on the timestamp.
      * Under the "Contract Result" section, the "Input - Function & Args" field should be a _relatively short_ set of hexadecimal values.
      * This is the representation of
        * the function identifier as the first _eight_ characters (e.g. `0xc63193f6` for the `introduce` function), and
        * the input string value (e.g. `0x5626775697a0` for `bguiz`).
      * Navigate back to the Contract page (browser `⬅` button).
-
-<img src="../../.gitbook/assets/hello-world--hscs--contract.drawing.svg" alt="HSCS contract in Hashscan, with annotated items to check." class="gitbook-drawing">
 
 <details>
 
@@ -316,7 +326,7 @@ You have learned how to:
 
 Now that you have completed this Hello World sequence, you have interacted with Hedera Smart Contract Service (HSCS). There are [other Hello World sequences](./) for Hedera File Service (HFS), and Hedera Token Service (HTS), which you may wish to check out next.
 
-You may also wish to check out the more detailed [HSCS workshop](https://docs.hedera.com/hedera/tutorials/smart-contracts/hscs-workshop/), which goes into much more depth.
+You may also wish to check out the more detailed [HSCS workshop](https://docs.hedera.com/hedera/tutorials/smart-contracts/hscs-workshop/), which goes into greater depth.
 
 ***
 
@@ -350,4 +360,4 @@ Note that the branch names are delimited by `..`, and not by `...`, as the latte
 
 ***
 
-**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**:[ Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)
+**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**: [Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)

--- a/tutorials/hello-world/hts-fungible-token.md
+++ b/tutorials/hello-world/hts-fungible-token.md
@@ -55,7 +55,7 @@ pwd
 
 This should output a path that ends with `/hello-future-world/04-hts-ft-sdk`. If not, you will need to start over.
 
-```
+```text
 /some/path/hello-future-world/04-hts-ft-sdk
 ```
 
@@ -67,7 +67,7 @@ ls -a
 
 The first few line of the output should look display `.env`. If not, you'll need to start over.
 
-```
+```text
 .
 ..
 .env
@@ -98,6 +98,7 @@ To create a new HTS token, we will use `TokenCreateTransaction`. This transactio
 * Set the decimal property to `2`.
 * Set the initial supply to 1 million.
 
+{% code title="script-hts-ft.js" overflow="wrap" %}
 ```js
         .setTokenType(TokenType.FungibleCommon)
         .setTokenName("bguiz coin")
@@ -105,6 +106,7 @@ To create a new HTS token, we will use `TokenCreateTransaction`. This transactio
         .setDecimals(2)
         .setInitialSupply(1_000_000)
 ```
+{% endcode %}
 
 <details>
 
@@ -132,9 +134,11 @@ You will want to use the Mirror Node API with the path `/api/v1/accounts/{idOrAl
 
 Using string interpolation, construct `accountBalanceFetchApiUrl` like so:
 
+{% code title="script-hts-ft.js" overflow="wrap" %}
 ```js
     const accountBalanceFetchApiUrl = `https://testnet.mirrornode.hedera.com/api/v1/accounts/${accountId}/tokens?token.id=${tokenId}&limit=1&order=desc`;
 ```
+{% endcode %}
 
 <details>
 
@@ -162,7 +166,7 @@ node script-hts-ft.js
 
 You should see output similar to the following:
 
-```
+```text
 accountId: 0.0.1201
 tokenId: 0.0.5878530
 tokenExplorerUrl: https://hashscan.io/testnet/token/0.0.5878530
@@ -172,12 +176,12 @@ accountBalanceFetchApiUrl: https://testnet.mirrornode.hedera.com/api/v1/accounts
 
 Open `tokenExplorerUrl` in your browser and check that:
 
-* The token should exist, and its "token ID" should match `tokenId`.
-* The "name" and "symbol" should be shown as the same values derived from your name (or nickname) that you chose earlier.
-* The "treasury account" should match `accountId`.
-* Both the "total supply" and "initial supply" should be `10,000`.
-
 <img src="../../.gitbook/assets/hello-world--hts--token.drawing.svg" alt="HTS transaction in Hashscan, with annotated items to check." class="gitbook-drawing">
+
+* The token should exist, and its "token ID" should match `tokenId`. **(1)**
+* The "name" and "symbol" should be shown as the same values derived from your name (or nickname) that you chose earlier. **(2)**
+* The "treasury account" should match `accountId`. **(3)**
+* Both the "total supply" and "initial supply" should be `10,000`. **(4)**
 
 {% hint style="info" %}
 **Note**: "total supply" and "initial supply" are not displayed as `1,000,000` because of the two decimal places configured. Instead, these are displayed as `10,000.00`.
@@ -232,4 +236,4 @@ Note that the branch names are delimited by `..`, and not by `...`, as the latte
 
 ***
 
-**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**:[ Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)
+**Writer**: [Brendan](https://blog.bguiz.com/) **Editors**: [Abi](https://github.com/a-ridley), [Michiel](https://www.linkedin.com/in/michielmulders/), [Ryan](https://www.linkedin.com/in/ryaneh/), [Krystal](https://www.linkedin.com/in/theekrystallee/)


### PR DESCRIPTION
**Description**:

## What

- [x] remove `lineNumbers="false"` attributes from `{% code %}` tags, as that had the opposite of the intended effect
- [x] add `{% code %}` tags to the other HW sequences
- [x] reinstate `(1)` etc when they reference annotations by number in screenshots
- [x] fix markdown syntax errors in footer for editor byline
- [x] remove trailing `&#x20;`whitespace character on various lines
- [x] add note in info box to state which EVM impl Hedera uses
- [x] misc proofreading: stray commas, simplify longer sentences, bold/italicise for emphasis, etc

## Why

- extrapolating previous reviews comments

## Refs

- example previous review comments: https://github.com/hedera-dev/preview-hedera-docs/pull/19

**Related issue(s)**:

- Preview: https://github.com/hedera-dev/preview-hedera-docs/pull/19

**Notes for reviewer**:

- These changes include inor proofreading edits only, no change to the substance

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.) - N/A
