### PR TITLE
Update hedera-json-rpc-relay.md

### DIFF
--- a/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
+++ b/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
@@ -88,7 +88,13 @@ npm install
 npm run build
 ```
 
-(4) Create or edit a file named `.env` in the root directory of this project, with the following fields set:
+(4) Create `.env` in the root directory of this project by copying `.env.example` and naming it `.env`.
+
+```shell
+cp .env.example .env
+```
+
+Then set the following fields:
 
 {% tabs %}
 {% tab title="Hedera Mainnet" %}

--- a/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
+++ b/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
@@ -120,16 +120,16 @@ For either **Previewnet or Testnet** you may use the Hedera Portal. See [Hedera 
 Note that setting up a **Mainnet** account and funding it is out of scope for this article.
 {% endhint %}
 
-(5a) Copy your account ID value into the `.env` file in the `OPERATOR_ID_MAIN` field.
+(5a) Copy your **Account ID** value into the `.env` file in the `OPERATOR_ID_MAIN` field.
 
-(5b) Copy your account's private key into the `.env` file in the `OPERATOR_KEY_MAIN` field.
+(5b) Copy your account's **DER Encoded Private Key** into the `.env` file in the `OPERATOR_KEY_MAIN` field.
 
-For example, if your account ID is `0.0.12345`, your private key is `0xa1b2c3`, and you are connecting to Testnet, the `.env` file should look like the following.
+For example, if your account ID is `0.0.12345`, your private key is `a1b2c3`, and you are connecting to Testnet, the `.env` file should look like the following.
 
 ```sh
 HEDERA_NETWORK=testnet
 OPERATOR_ID_MAIN=0.0.12345
-OPERATOR_KEY_MAIN=0xa1b2c3
+OPERATOR_KEY_MAIN=a1b2c3
 CHAIN_ID=0x128
 MIRROR_NODE_URL=https://testnet.mirrornode.hedera.com/
 ```

--- a/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
+++ b/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
@@ -82,7 +82,7 @@ cd hedera-json-rpc-relay
 npm install
 ```
 
-(3) Build the project's sub-packages.
+(3) Build the project, including its sub-packages.
 
 ```sh
 npm run build
@@ -129,7 +129,7 @@ For example, if your account ID is `0.0.12345`, your private key is `a1b2c3`, an
 ```sh
 HEDERA_NETWORK=testnet
 OPERATOR_ID_MAIN=0.0.12345
-OPERATOR_KEY_MAIN=a1b2c3
+OPERATOR_KEY_MAIN=302e0201...
 CHAIN_ID=0x128
 MIRROR_NODE_URL=https://testnet.mirrornode.hedera.com/
 ```

--- a/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
+++ b/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
@@ -88,7 +88,7 @@ npm install
 npm run build
 ```
 
-(4) Create `.env` in the root directory of this project by copying `.env.example` and naming it `.env`.
+(4) Create a file named `.env` in the root directory of this project by copying `.env.example` and naming it `.env`.
 
 ```shell
 cp .env.example .env

--- a/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
+++ b/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay.md
@@ -75,17 +75,17 @@ git clone -b main --single-branch git@github.com:hashgraph/hedera-json-rpc-relay
 
 </details>
 
-(2) Enter the directory that you have cloned, and install dependencies. It is recommended that you have NodeJS version `18` or later for this.
+(2) Enter the directory that you have cloned, and install dependencies. It is recommended that you have NodeJS version `20` or later for this.
 
 ```sh
 cd hedera-json-rpc-relay
 npm install
 ```
 
-(3) Link dependencies within its sub-packages.
+(3) Build the project's sub-packages.
 
 ```sh
-npm run setup
+npm run build
 ```
 
 (4) Create or edit a file named `.env` in the root directory of this project, with the following fields set:


### PR DESCRIPTION
**Description**:
Update the [Configuring Hedera JSON-RPC Relay endpoints](https://docs.hedera.com/hedera/tutorials/more-tutorials/json-rpc-connections/hedera-json-rpc-relay) page. It seems to be outdated:

### setup -> build
The page has a step 3 that says to run `npm run setup`. But there is no longer any `setup` script in the [hedera-json-rpc-relay](https://github.com/hashgraph/hedera-json-rpc-relay) repo, so the `npm run setup` command fails. Looking at the current state of the repo, its readme mentions a `build` script (apparently a required step). So I figured that the `setup` step can change to mention `build` instead.

For context, the project uses `lerna` which builds monorepos. Long ago, lerna was used to link packages together, which is probably what the `setup` script did. But now, linking is done automatically by the package manager (e.g. npm) with a `workspaces` configuration. So setup is typically no longer required in lerna projects.

### node 20

The page mentions node 18 as a valid node version, but the [hedera-json-rpc-relay](https://github.com/hashgraph/hedera-json-rpc-relay) readme specifically mentions node 20, so I figured this article should align with that. Feel free to revert if not.

### `.env` instructions

The `.env.` instructions seemed slightly outdated, so while we're here it makes sense to update them, to be similar to the instructions on the [Setup](https://docs.hedera.com/hedera/tutorials/smart-contracts/hscs-workshop/setup#step-b1-environment-variables-file) page. Though, the wording needed to be adapted to preserve the imperative style of these steps, because each point began with an action verb ("Clone", "Enter", "Link", "Create" ...)

The existing text was outdated because it said "create or edit an `.env` file" but for readers who are following the steps --- they have freshly cloned the repo so there is no existing `.env` file. And the project now has an `.env.example` file, which is meant to be copied to create an `.env` file.

### `.env` contents

The page contents said to "copy your account's private key",  but the Hedera Portal lists the private key in two ways: hex-encoded and DER-encoded. The steps should say which one to copy.

Based on [env.sample](https://github.com/hashgraph/hedera-json-rpc-relay/blob/f55251ec59a04a3a09b46d971beb141ad9b3dd75/docs/examples/.env.sample), it seems that the DER-encoded format is the one to use, though I might be wrong. I updated the page to have sample values that look like DER-encoded keys instead of hex-encoded.