### PR TITLE
Update the Hedera SDK JS docs page

### DIFF
--- a/tutorials/smart-contracts/hscs-workshop/hedera-sdk-js.md
+++ b/tutorials/smart-contracts/hscs-workshop/hedera-sdk-js.md
@@ -44,7 +44,8 @@ In this tutorial, you will be using Hedera SDK JS to interact with HSCS. Specifi
 
 ## Prerequisites
 
-* ✅ Complete the [Introduction](00-intro.md) section of this same tutorial.
+* ✅ Complete the [Setup](setup.md) section of this same tutorial.
+* ✅ Complete the [Solidity](solidity.md) section of this same tutorial.
 
 ## Set up the project
 


### PR DESCRIPTION
**Description**:
The [Hedera SDK JS](https://docs.hedera.com/hedera/tutorials/smart-contracts/hscs-workshop/hedera-sdk-js) page needed some fixes.

### Broken link: Introduction

Under the Prerequisites section, the "Introduction" link was broken. The page is now called "Setup".

### Missing prerequisite: Solidity

It's necessary that the [Solidity](https://docs.hedera.com/hedera/tutorials/smart-contracts/hscs-workshop/solidity) tutorial is followed beforehand, otherwise `trogdor.sol` will fail to compile because it has unfilled placeholder comments.