### PR TITLE
Update on environment-set-up.md

### DIFF
--- a/getting-started/environment-set-up.md
+++ b/getting-started/environment-set-up.md
@@ -345,7 +345,7 @@ go run hedera_examples.go
 Create a Hedera Testnet [client](../support-and-community/glossary.md#client) and set the operator information using the testnet account ID and private key for transaction and query fee authorization. The _operator_ is the default account that will pay for the transaction and query fees in HBAR. You will need to sign the transaction or query with the private key of that account to authorize the payment. In this case, the operator ID is your testnet account ID, and the operator private key is the corresponding testnet account private key.
 
 {% hint style="warning" %}
-To avoid encountering the **`INSUFFICIENT_TX_FEE`** error while conducting transactions, you can adjust the maximum transaction fee limit through the **`.setDefaultMaxTransactionFee()`** method. Similarly, the maximum query payment can be adjusted using the **`.setDefaultMaxQueryPayment()`** method.
+To avoid encountering the **`INSUFFICIENT_TX_FEE`** error while conducting transactions, you can adjust the maximum transaction fee limit through the **`.setDefaultMaxTransactionFee()`** method. Similarly, the maximum query payment can be adjusted using the **`.setMaxQueryPayment()`** method.
 {% endhint %}
 
 <details>
@@ -383,7 +383,7 @@ client.setOperator(myAccountId, myPrivateKey);
 client.setDefaultMaxTransactionFee(new Hbar(100));
 
 //Set the maximum payment for queries (in Hbar)
-client.setDefaultMaxQueryPayment(new Hbar(50));
+client.setMaxQueryPayment(new Hbar(50));
 ```
 {% endtab %}
 
@@ -399,7 +399,7 @@ client.setOperator(myAccountId, myPrivateKey);
 client.setDefaultMaxTransactionFee(new Hbar(100));
 
 //Set the maximum payment for queries (in Hbar)
-client.setDefaultMaxQueryPayment(new Hbar(50));
+client.setMaxQueryPayment(new Hbar(50));
 ```
 {% endtab %}
 
@@ -413,7 +413,7 @@ client.SetOperator(myAccountId, myPrivateKey)
 client.SetDefaultMaxTransactionFee(hedera.HbarFrom(100, hedera.HbarUnits.Hbar))
 
 // Set max query payment
-client.SetDefaultMaxQueryPayment(hedera.HbarFrom(50, hedera.HbarUnits.Hbar))
+client.setMaxQueryPayment(hedera.HbarFrom(50, hedera.HbarUnits.Hbar))
 ```
 {% endtab %}
 {% endtabs %}
@@ -459,7 +459,7 @@ public class HederaExamples {
         client.setOperator(myAccountId, myPrivateKey);
         // Set default max transaction fee &#x26; max query payment
         client.setDefaultMaxTransactionFee(new Hbar(100)); 
-        client.setDefaultMaxQueryPayment(new Hbar(50)); 
+        client.setMaxQueryPayment(new Hbar(50)); 
         
         System.out.println("Client setup complete.");
     }
@@ -503,7 +503,7 @@ async function environmentSetup() {
   client.setDefaultMaxTransactionFee(new Hbar(100));
 
   //Set the maximum payment for queries (in Hbar)
-  client.setDefaultMaxQueryPayment(new Hbar(50));
+  client.setMaxQueryPayment(new Hbar(50));
   
   console.log("Client setup complete.");
 }
@@ -553,7 +553,7 @@ func main() {
 	client.SetOperator(myAccountId, myPrivateKey)
 	// Set default max transaction fee & max query payment
 	client.SetDefaultMaxTransactionFee(hedera.HbarFrom(100, hedera.HbarUnits.Hbar))
-	client.SetDefaultMaxQueryPayment(hedera.HbarFrom(50, hedera.HbarUnits.Hbar))
+	client.setMaxQueryPayment(hedera.HbarFrom(50, hedera.HbarUnits.Hbar))
 	
 	fmt.Println(“Client setup complete.”)
 }


### PR DESCRIPTION
The SetDefaultMaxQueryPayment() is not working. I changed it to SetMaxQueryPayment() which is working without an error and which has been used in the bta hashgraph tutorial

**Description**:

This PR modifies the beginner code index.js content in the environment set up since errors were occuring when running the provided code snippet for javascript...
* Change of SetDefaultMaxQueryPayment() function to SetMaxQueryPayment()

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

![image](https://github.com/user-attachments/assets/30b695ea-aaf6-490d-b64e-49c30ae87d05)


