### PR TITLE
Update transfer-hbar.md to remove code that is not consistent with code check

### DIFF
--- a/getting-started/transfer-hbar.md
+++ b/getting-started/transfer-hbar.md
@@ -31,7 +31,7 @@ Use your new account created in the "[Create an account](create-an-account.md)" 
 //Transfer HBAR
 TransactionResponse sendHbar = new TransferTransaction()
      .addHbarTransfer(myAccountId, Hbar.fromTinybars(-1000)) //Sending account
-     .addHbarTransfer(newAccountId, evmAddress, Hbar.fromTinybars(1000)) //Receiving account
+     .addHbarTransfer(newAccountId, Hbar.fromTinybars(1000)) //Receiving account
      .execute(client);
 ```
 {% endtab %}
@@ -44,7 +44,7 @@ TransactionResponse sendHbar = new TransferTransaction()
 //Create the transfer transaction
 const sendHbar = await new TransferTransaction()
      .addHbarTransfer(myAccountId, Hbar.fromTinybars(-1000)) //Sending account
-     .addHbarTransfer(newAccountId, evmAddress, Hbar.fromTinybars(1000)) //Receiving account
+     .addHbarTransfer(newAccountId, Hbar.fromTinybars(1000)) //Receiving account
      .execute(client);
 ```
 {% endtab %}
@@ -58,7 +58,7 @@ const sendHbar = await new TransferTransaction()
 //Transfer hbar from your testnet account to the new account
 transaction := hedera.NewTransferTransaction().
         AddHbarTransfer(myAccountId, hedera.HbarFrom(-1000, hedera.HbarUnits.Tinybar)).
-        AddHbarTransfer(newAccountId, evmAddress, hedera.HbarFrom(1000, hedera.HbarUnits.Tinybar))
+        AddHbarTransfer(newAccountId, hedera.HbarFrom(1000, hedera.HbarUnits.Tinybar))
 
 //Submit the transaction to a Hedera network
 txResponse, err := transaction.Execute(client)


### PR DESCRIPTION
Description:

This PR fixes a minor code discrepancy present in one getting started document:
- Removed evmAddress parameter that was being used in "Step 1" but was not in "Code Check"

Signed-off-by: Author Name [andre.aa.rocha@outlook.com](mailto:andre.aa.rocha@outlook.com)
