### PR TITLE
update the hedera node spec disk i/o section (MBps instead of GBps) & update values to match current spec

### DIFF
--- a/networks/mainnet/mainnet-nodes/node-requirements/README.md
+++ b/networks/mainnet/mainnet-nodes/node-requirements/README.md
@@ -32,20 +32,20 @@ To ensure accurate conformity with the minimum requirements, please provide node
     * 2 x NVMe devices as a 7.5TB RAID 0 (or 4x as RAID 10 array)
 * Storage performance: If mounted to root volume, the root volume must meet these requirements. If provisioned via RAID, the RAID array should meet these requirements:
   * Sequential write sustained:
-    * Minimum: 2,000GB/s
-    * Recommended: 3,000GB/s
+    * Minimum: 2,000 MBps
+    * Recommended: 3,000 MBps
   * Sequential read sustained:
-    * Minimum: 3,000GB/s
-    * Recommended: 4,500GB/s
+    * Minimum: 3,000 MBps
+    * Recommended: 6,200 MBps
   * Random read, synchronous:
     * Minimum: 250,000 IOPS
-    * Recommended: 375,000 IOPS
+    * Recommended: 1,000,000 IOPS
   * Random read, AIO:
     * Minimum: 500,000 IOPS
-    * Recommended: 750,000 IOPS
+    * Recommended: 1,000,000 IOPS
   * Random write, synchronous:
-    * Minimum 100,000 IOPS
-    * Recommended: 150,000 IOPS
+    * Minimum: 100,000 IOPS
+    * Recommended: 170,000 IOPS
   * Less than 200µs random read latency, average
 * Nodes must pass the Hedera performance test suite performed at installation time
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR:
* updates the Hedera Node Spec to be MBps instead of GBps
* updates the values to match the current specs listed in our benchmark:
	![screenshot-20241018-17-08-50-PT](https://github.com/user-attachments/assets/38120cd0-91e9-409a-baa7-bd7d88f9c278)




**Related issue(s)**:

* Fixes #784
* Followup to https://github.com/hashgraph/hedera-docs/pull/432

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
