### PR TITLE
Update run-your-own-mirror-node-s3.md

### DIFF
--- a/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-s3.md
+++ b/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-s3.md
@@ -106,7 +106,7 @@ Start and run the Hedera Mirror Node using Docker. Docker packages development t
 * From the mirror node directory, run the following command:
 
 ```bash
-docker compose up -d db && docker logs hedera-mirror-node-db-1 --follow
+docker compose up -d && docker logs hedera-mirror-node-importer-1 --follow
 ```
 
 ## 5. Access Your Mirror Node Data


### PR DESCRIPTION
**Description**:

This PR fixes the doc as follow:
1. The users must start all the services, not just the DB
2. I suggest to follow the log of the importer: it shows more interesting activities than the DB.

**Related issue(s)**:

N/A

**Notes for reviewer**:

A user followed the tutorial and reached out on Discord for support.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
