### PR TITLE
fix: move badges below frontmatter to restore cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hiero-ledger/hiero-docs/badge)](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-docs)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/10697/badge)](https://bestpractices.coreinfrastructure.org/projects/10697)
-[![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
-
 ---
 cover: .gitbook/assets/hiero-docs-landing-hero-cover.png
 coverY: 0
@@ -20,6 +16,10 @@ layout:
   pagination:
     visible: true
 ---
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hiero-ledger/hiero-docs/badge)](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-docs)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/10697/badge)](https://bestpractices.coreinfrastructure.org/projects/10697)
+[![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
 
 # Welcome to Hiero Documentation
 


### PR DESCRIPTION
**Description**:
The three badge lines before the opening --- caused GitBook to treat the cover/layout configuration as body text rather than page metadata, resulting in the cover image not rendering on docs.hiero.org.

Moving badges to after the closing --- so the YAML frontmatter is parsed correctly and the hero cover image is restored.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
UI changes

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
