### PR TITLE
docs(block-node): register Block Node Introduction in nav and landing page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,7 @@
   * [Hiero Rust SDK](https://github.com/hiero-ledger/hiero-sdk-rust)
   * [Hiero Swift SDKs](https://github.com/hiero-ledger/hiero-sdk-swift)
 * [Hiero Block Node](block-node/block-node-home.md)
+  * [Block Node Introduction](block-node/block-node/block-node-introduction.md)
   * [Block Node Overview](block-node/block-node/block-node-overview.md)
   * [Block Node Types and Tiers](block-node/Block-Node-Types.md)
   * [Architecture Overview](block-node/block-node/architecture/architecture-overview.md)

--- a/block-node/block-node-home.md
+++ b/block-node/block-node-home.md
@@ -3,6 +3,7 @@
 Hiero Block Nodes form the decentralised data layer of a Hiero network — receiving, verifying, storing, and serving the block stream produced by Consensus Nodes.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody>
+<tr><td><strong>Block Node Introduction</strong></td><td>New to Block Nodes? Start here - what a Block Node is, who it is for, and where to go next based on your role.</td><td><a href="block-node/block-node-introduction.md">block-node-introduction.md</a></td></tr>
 <tr><td><strong>Block Node Overview</strong></td><td>What a Block Node is, how it fits in the Hiero network, tiers, deployment profiles, and operator responsibilities.</td><td><a href="block-node/block-node-overview.md">block-node-overview.md</a></td></tr>
 <tr><td><strong>Block Node Types and Tiers</strong></td><td>Full taxonomy of Block Node types: Rolling-History, Full Node, Light Node, Private-Cloud, Archive Server, and Community Node.</td><td><a href="Block-Node-Types.md">Block-Node-Types.md</a></td></tr>
 <tr><td><strong>Deployment</strong></td><td>Hardware requirements, Solo Provisioner setup, Kubernetes deployment, and local development quickstart.</td><td><a href="deployment.md">deployment.md</a></td></tr>


### PR DESCRIPTION
**Description**:
Adds block-node-introduction.md to SUMMARY.md and adds a "New to Block Nodes? Start here" card to block-node-home.md.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Depends on https://github.com/hiero-ledger/hiero-block-node/pull/3490 merging and the sync-docs-to-gitbook workflow running before this can be merged - the target file does not exist in this repo until the sync lands.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
