### PR TITLE
ci: add CodeQL workflow analysis and Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "17 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: hl-docs-lin-md
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.scorecard.yml
+++ b/.scorecard.yml
@@ -1,6 +1,5 @@
 annotations:
   - checks:
-      - sast
       - packaging
       - signed-releases
       - fuzzing


### PR DESCRIPTION
**Description**:

Raise the repository's [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-docs) score by adding static analysis of the GitHub Actions workflows. The repo already scores 10 on Token-Permissions, Pinned-Dependencies, Binary-Artifacts and Dangerous-Workflow; SAST is currently 0 because no analysis tool runs on any commit.

The only language GitHub reports for this repo is Shell (a git hook), so the CodeQL matrix is limited to the `actions` language, which analyses the workflow YAML in `.github/workflows/` for injection, unpinned-action and permission issues. This is applicable even for a docs-only repo, since `gitbook-auto-signoff.yml` runs with `contents: write` and force-pushes to `master`.

**Changes**:

*SAST*
* Add `.github/workflows/codeql.yml` (language `actions`, build-mode `none`) triggered on `push`/`pull_request` to `master` and a weekly schedule. Runs on `hl-docs-lin-md` like `link-check.yml`, uses the same `harden-runner` (v2.20.0) and `actions/checkout` (v4.2.2) SHA pins already used in this repo, and pins `github/codeql-action` to v4.37.9. Top-level `permissions` is `contents: read`; `security-events: write` is granted only at job level.
* Remove `sast` from the `not-applicable` annotation in `.scorecard.yml`, since a SAST tool now runs here. The `packaging`, `signed-releases` and `fuzzing` annotations are unchanged.

*Dependency freshness*
* Add `.github/dependabot.yml` for the `github-actions` ecosystem (weekly) so the SHA pins in the workflows keep receiving update PRs.

| Check | Before | After (local `scorecard --local`) |
|---|---|---|
| SAST | 0 | 10 (7 immediately on the public cron, 10 once the workflow has run on PRs) |
| Token-Permissions | 10 | 10 |
| Pinned-Dependencies | 10 | 10 |
| Binary-Artifacts | 10 | 10 |
| Dangerous-Workflow | 10 | 10 |

**Intentionally not changed**:
* Fuzzing: still annotated as not-applicable (no fuzzable code in this repo).
* `link-check.yml` downloads a `lychee` release tarball with `curl` and executes it; scorecard does not flag this as `downloadThenRun`, so it is left as is. Pinning the tarball to a checksum could be a follow-up.
* Existing workflow pins (`harden-runner` v2.12.0 / v2.20.0, `checkout` v4.2.2) are left alone; Dependabot will propose bumps.
* `.github/audits/rules.md` (Exception 2) records that a Dependabot configuration is not required here because the repo only contains bash scripts. The `dependabot.yml` added in this PR covers only the `github-actions` ecosystem, i.e. the SHA pins in the three workflow files, so that exception becomes moot once this merges. I have not edited `rules.md`; if you would rather keep the exception as recorded, drop `dependabot.yml` from this PR and the CodeQL change stands on its own.

**Related issue(s)**:

N/A

**Notes for reviewer**:

Verification:
* `actionlint .github/workflows/codeql.yml` reports only the pre-existing "unknown self-hosted label `hl-docs-lin-md`" notice, same as `link-check.yml`.
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` gives the table above.
* The `CodeQL / Analyze (actions)` check on this PR is the first run of the new workflow.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

